### PR TITLE
Fix downloading link in `setup.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repository contains the databases with all mitotic figure annotations of th
 
 All requirements needed to run the scripts in this repository can be installed using pip:
 
-```pip -r requirements.txt```
+```pip install -r requirements.txt```
 
 To download all files from figshare, please run the notebook [Setup.ipynb](Setup.ipynb). It will place all 65 GB of images in the images folder.
 

--- a/Setup.ipynb
+++ b/Setup.ipynb
@@ -519,9 +519,7 @@
     " '40283728': '547.tiff',\n",
     " '40283731': '549.tiff',\n",
     " '40283734': '551.tiff',\n",
-    " '40283740': '553.tiff',\n",
-    " '40283737': 'MIDOGpp.json',\n",
-    " '40283743': 'MIDOGpp.sqlite'}"
+    " '40283740': '553.tiff',}"
    ]
   },
   {
@@ -544,7 +542,7 @@
     "from tqdm import tqdm\n",
     "\n",
     "for file in tqdm(filename):\n",
-    "    url = f'https://figshare.com/ndownloader/files/{file}?private_link=bcb4228247770ff4e03e'\n",
+    "    url = f'https://figshare.com/ndownloader/files/{file}?=bcb4228247770ff4e03e'\n",
     "    urlretrieve(url, 'images'+os.sep+filename[file])\n",
     "\n"
    ]


### PR DESCRIPTION
- remove `private_link` in web address for downloading .tiff files from setup.py\
- remove .json and .sqlite from being downloaded
- add install in README.md (pip install)

#9 